### PR TITLE
Add history as top-level dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "babel-plugin-react-transform": "^1.1.1",
     "chroma-js": "0.7.2",
     "color-pairs-picker": "^1.3.5",
+    "history": "^2.0.0",
     "lodash": "^4.5.0",
     "react": "^0.14.7",
     "react-document-title": "^2.0.1",


### PR DESCRIPTION
was causing the webpack build to fail (cf similar problem fixed in gatsbyjs/gatsby#174)
